### PR TITLE
Remove the word staging

### DIFF
--- a/environments/staging/environment.yaml
+++ b/environments/staging/environment.yaml
@@ -1,5 +1,5 @@
 #
-# Configuration for staging environment
+# Configuration for environment
 #
 version: 1.0
 app:


### PR DESCRIPTION
`staging/environment.yaml` may be used to create other environments like `production/environment.yaml`. The user may forget to update the world `staging` to `production`. 

My proposal is to let the directory name be the source of truth on what environment it is (staging, production, ...)